### PR TITLE
Fixed issue where deleted tables/indexes result in failures

### DIFF
--- a/indexes/dba_indexDefrag_sp.sql
+++ b/indexes/dba_indexDefrag_sp.sql
@@ -782,6 +782,8 @@ BEGIN
                 , @partitionNumber_Out  = @partitionNumber  OUTPUT
                 , @pageCount_Out        = @pageCount        OUTPUT;
 
+            SELECT @debugMessage = '  Picked object ID ' + CAST(@objectID AS VARCHAR(10)) +  ' and index ID ' + CAST(@indexID AS VARCHAR(10))
+            IF @debugMode = 1 RAISERROR(@debugMessage, 0, 42) WITH NOWAIT;
             IF @debugMode = 1 RAISERROR('  Looking up the specifics for our index...', 0, 42) WITH NOWAIT;
 
             /* Look up index information */
@@ -903,8 +905,11 @@ BEGIN
             IF @executeSQL = 1
             BEGIN
 
-                SET @debugMessage = 'Executing: ' + @sqlCommand;
-                
+                IF (@sqlCommand IS NOT NULL AND LEN(@sqlCommand) > 0)
+                    SET @debugMessage = 'Executing: ' + @sqlCommand;
+                ELSE
+                    SET @debugMessage = 'Skipping index because it''s name could not be found';
+
                 /* Print the commands we're executing if specified to do so */
                 IF @printCommands = 1 OR @debugMode = 1
                     RAISERROR(@debugMessage, 0, 42) WITH NOWAIT;
@@ -931,9 +936,9 @@ BEGIN
                       @databaseID
                     , @databaseName
                     , @objectID
-                    , @objectName
+                    , ISNULL(@objectName, '<unknown>')
                     , @indexID
-                    , @indexName
+                    , ISNULL(@indexName, '<unknown>')
                     , @partitionNumber
                     , @fragmentation
                     , @pageCount
@@ -946,7 +951,8 @@ BEGIN
                 BEGIN TRY
 
                     /* Execute our defrag! */
-                    EXECUTE sp_executesql @sqlCommand;
+                    IF (@sqlCommand IS NOT NULL AND LEN(@sqlCommand) > 0)
+                        EXECUTE sp_executesql @sqlCommand;
                     SET @dateTimeEnd = GETDATE();
                     
                     /* Update our log with our completion time */


### PR DESCRIPTION
We encountered an issue where the script will become "stuck" if the next index to work on has been deleted, or it's associated table has been deleted.

We run the script nightly with a 2 hour time limit, so it usually takes a few days for it to process all the fragmented indexes. If during that time, we remove a table/index that was in the queue for processing then the script would stop processing.

This change attempts to skip an index if it's going to fail.
