### PR TITLE
update dba_defragindex_sp to allow columnstore

### DIFF
--- a/indexes/dba_indexDefrag_sp.sql
+++ b/indexes/dba_indexDefrag_sp.sql
@@ -889,8 +889,7 @@ BEGIN
                 /* Set sort operation preferences */
                 IF @sortInTempDB = 1 
                     SET @rebuildCommand = @rebuildCommand + N', SORT_IN_TEMPDB = ON';
-                ELSE
-                    SET @rebuildCommand = @rebuildCommand + N', SORT_IN_TEMPDB = Off';
+                
 
                 /* Set processor restriction options; requires Enterprise Edition */
                 IF @maxDopRestriction IS NOT NULL AND @editionCheck = 1


### PR DESCRIPTION
ColumnStore Index dissallow SORT_IN_TEMPDB parameter, so in order to rebuild these index, when the @sort_in_tempdb variable is set to 0 then no more SORT_IN_TEMPDB=OFF --> the ELSE part is removed.